### PR TITLE
added support for multiple backbone resnet models

### DIFF
--- a/app/models/resnet.py
+++ b/app/models/resnet.py
@@ -1,11 +1,23 @@
 import torch.nn as nn
 from torchvision.models.resnet import ResNet, Bottleneck
 
-class ResNet50(ResNet):
-    def __init__(self, in_channels, norm_layer=None):
+resnet_config = {
+    'resnet50': [3, 4, 6, 3],
+    'resnet101': [3, 4, 23, 3],
+    # 'resnet18': [2, 2, 2, 2],
+    # 'resnet34': [3, 4, 6, 3],
+    # 'resnet152': [3, 8, 36, 3],
+}
+
+
+class ResNetBackBone(ResNet):
+    def __init__(self, in_channels, norm_layer=None, name='resnet50'):
+        if name.lower() not in resnet_config:
+            raise ValueError('Name of the backbone resnet must be one of the available architectures')
+
         super().__init__(
             block=Bottleneck,
-            layers=[3, 4, 6, 3],
+            layers=resnet_config[name.lower()],
             replace_stride_with_dilation=[False, False, True],
             norm_layer=norm_layer
         )


### PR DESCRIPTION
Hey! I added support for multiple backbone resnet models for your implementation, which is basically a `dict` that provides layer information given the name of the model since different resnets do computation in a similar manner. The default behavior is the same as your original version. 

I intended to implement a class for all 5 models, but I realized that the source for pretrained models you are using only contains files for resnet50 and resnet101, so I include the other models in comments. And because I'm not sure how you would like the arguments to be passed to the model classes, I left the part for training unchanged